### PR TITLE
Stop using points in vectors and colors

### DIFF
--- a/geometry/sphere.go
+++ b/geometry/sphere.go
@@ -23,7 +23,7 @@ func (sphere *Sphere) Material() raytracer.Material {
 func (sphere *Sphere) Hit(ray *raytracer.Ray) {
 	a := ray.Direction.DotProduct(ray.Direction)
 
-	eMinC := ray.Eye.Subtract(&sphere.Center)
+	eMinC := ray.Eye.Subtract(sphere.Center)
 	b := ray.Direction.DotProduct(eMinC) * 2.0
 	c := eMinC.DotProduct(eMinC) - sphere.radius2()
 	discriminant := b*b - (4 * a * c)
@@ -40,6 +40,6 @@ func (sphere *Sphere) Hit(ray *raytracer.Ray) {
 	}
 
 	if ray.IsHit(t1, sphere) || ray.IsHit(t2, sphere) {
-		ray.Normal = ray.HitPoint().Subtract(&sphere.Center).Normalize()
+		ray.Normal = ray.HitPoint().Subtract(sphere.Center).Normalize()
 	}
 }

--- a/geometry/triangle.go
+++ b/geometry/triangle.go
@@ -1,0 +1,21 @@
+package geometry
+
+/*
+import (
+	"github.com/stijndehaes/go-tracer/math"
+	"github.com/stijndehaes/go-tracer/raytracer"
+)
+
+type Triangle struct {
+	Vertex0, Vertex1, Vertex2 math.Vector3
+	TriangleMaterial raytracer.Material
+}
+
+func (t *Triangle) Material() raytracer.Material {
+	return t.TriangleMaterial
+}
+
+func (t *Triangle) Hit(ray *raytracer.Ray) {
+	v0v1 := t.Vertex1.Subtract(t.Vertex0)
+}
+*/

--- a/integrators/direct_lightning_integrator.go
+++ b/integrators/direct_lightning_integrator.go
@@ -9,10 +9,10 @@ type DirectLightningIntegrator struct {
 	Scene *raytracer.Scene
 }
 
-func (integrator *DirectLightningIntegrator) RenderRay(ray *raytracer.Ray) *math.Color3 {
+func (integrator *DirectLightningIntegrator) RenderRay(ray *raytracer.Ray) math.Color3 {
 	integrator.Scene.Accelerator.IntersectGeometry(ray)
 
-	color := &math.Color3{}
+	color := math.Color3{}
 	if !ray.Hit {
 		return color
 	}
@@ -23,7 +23,7 @@ func (integrator *DirectLightningIntegrator) RenderRay(ray *raytracer.Ray) *math
 	return color
 }
 
-func (integrator *DirectLightningIntegrator) shadeGeometryWithLight(light raytracer.Light, ray *raytracer.Ray) *math.Color3 {
+func (integrator *DirectLightningIntegrator) shadeGeometryWithLight(light raytracer.Light, ray *raytracer.Ray) math.Color3 {
 	hit := ray.HitPoint()
 	direction, distance, color := light.SampleLight(hit)
 	lightRay := &raytracer.Ray{Eye: hit, Direction: direction, HitDistance: distance}
@@ -32,6 +32,6 @@ func (integrator *DirectLightningIntegrator) shadeGeometryWithLight(light raytra
 	if !lightRay.Hit && dirMulNormal > 0 {
 		return ray.Geometry.Material().Shade(ray.Direction, direction, ray).Multiply(color).MultiplyFloat(dirMulNormal)
 	} else {
-		return &math.Color3{}
+		return math.Color3{}
 	}
 }

--- a/lights/point_light.go
+++ b/lights/point_light.go
@@ -9,7 +9,7 @@ type PointLight struct {
 	Origin *math.Vector3
 }
 
-func (light PointLight) SampleLight(hit *math.Vector3) (*math.Vector3, float64, *math.Color3) {
+func (light PointLight) SampleLight(hit math.Vector3) (math.Vector3, float64, math.Color3) {
 	temp := light.Origin.Subtract(hit)
 	direction := temp.Normalize()
 	distance := temp.Norm()

--- a/main.go
+++ b/main.go
@@ -16,16 +16,16 @@ import (
 func main() {
 	canvas := utils.CreateCanvas(image.Point{X: 1000, Y: 1000})
 	camera := raytracer.GetCamera(
-		&math.Vector3{X: -8},
-		&math.Vector3{Y: 1.0},
-		&math.Vector3{X: 1.0},
+		math.Vector3{X: -8},
+		math.Vector3{Y: 1.0},
+		math.Vector3{X: 1.0},
 		75.0,
 		1.0,
 		1000,
 		1000,
 	)
 
-	colors := []*math.Color3{
+	colors := []math.Color3{
 		{R: gomath.Pi},
 		{G: gomath.Pi},
 		{B: gomath.Pi},

--- a/materials/diffuse_material.go
+++ b/materials/diffuse_material.go
@@ -6,9 +6,9 @@ import (
 )
 
 type DiffuseMaterial struct {
-	Reflectance *math.Color3
+	Reflectance math.Color3
 }
 
-func (mat *DiffuseMaterial) Shade(in *math.Vector3, out *math.Vector3, ray *raytracer.Ray) *math.Color3 {
+func (mat *DiffuseMaterial) Shade(in math.Vector3, out math.Vector3, ray *raytracer.Ray) math.Color3 {
 	return mat.Reflectance
 }

--- a/math/color3.go
+++ b/math/color3.go
@@ -9,7 +9,7 @@ type Color3 struct {
 	R, G, B float64
 }
 
-func (color *Color3) RGBA64() gocolor.RGBA64 {
+func (color Color3) RGBA64() gocolor.RGBA64 {
 	return gocolor.RGBA64{
 		R: uint16(gomath.Max(0, gomath.Min(color.R*gomath.MaxUint16, gomath.MaxUint16))),
 		G: uint16(gomath.Max(0, gomath.Min(color.G*gomath.MaxUint16, gomath.MaxUint16))),
@@ -18,18 +18,18 @@ func (color *Color3) RGBA64() gocolor.RGBA64 {
 	}
 }
 
-func (color *Color3) DivideFloat(float float64) *Color3 {
+func (color Color3) DivideFloat(float float64) Color3 {
 	return color.MultiplyFloat(1 / float)
 }
 
-func (color *Color3) MultiplyFloat(float float64) *Color3 {
-	return &Color3{R: color.R * float, G: color.G * float, B: color.B * float}
+func (color Color3) MultiplyFloat(float float64) Color3 {
+	return Color3{R: color.R * float, G: color.G * float, B: color.B * float}
 }
 
-func (color *Color3) Multiply(color2 *Color3) *Color3 {
-	return &Color3{R: color.R * color2.R, G: color.G * color2.G, B: color.B * color2.B}
+func (color Color3) Multiply(color2 Color3) Color3 {
+	return Color3{R: color.R * color2.R, G: color.G * color2.G, B: color.B * color2.B}
 }
 
-func (color *Color3) Add(color2 *Color3) *Color3 {
-	return &Color3{R: color.R + color2.R, G: color.G + color2.G, B: color.B + color2.B}
+func (color Color3) Add(color2 Color3) Color3 {
+	return Color3{R: color.R + color2.R, G: color.G + color2.G, B: color.B + color2.B}
 }

--- a/math/vector3.go
+++ b/math/vector3.go
@@ -6,57 +6,57 @@ type Vector3 struct {
 	X, Y, Z float64
 }
 
-func (first *Vector3) Add(second *Vector3) *Vector3 {
-	return &Vector3{
+func (first Vector3) Add(second Vector3) Vector3 {
+	return Vector3{
 		X: first.X + second.X,
 		Y: first.Y + second.Y,
 		Z: first.Z + second.Z,
 	}
 }
 
-func (first *Vector3) Subtract(second *Vector3) *Vector3 {
-	return &Vector3{
+func (first Vector3) Subtract(second Vector3) Vector3 {
+	return Vector3{
 		X: first.X - second.X,
 		Y: first.Y - second.Y,
 		Z: first.Z - second.Z,
 	}
 }
 
-func (first *Vector3) Norm() float64 {
+func (first Vector3) Norm() float64 {
 	return math.Sqrt(first.X*first.X + (first.Y * first.Y) + (first.Z * first.Z))
 }
 
-func (first *Vector3) Normalize() *Vector3 {
+func (first Vector3) Normalize() Vector3 {
 	normal := first.Norm()
-	return &Vector3{
+	return Vector3{
 		X: first.X / normal,
 		Y: first.Y / normal,
 		Z: first.Z / normal,
 	}
 }
 
-func (first *Vector3) MultiplyFloat(f float64) *Vector3 {
-	return &Vector3{
+func (first Vector3) MultiplyFloat(f float64) Vector3 {
+	return Vector3{
 		X: first.X * f,
 		Y: first.Y * f,
 		Z: first.Z * f,
 	}
 }
 
-func (first *Vector3) Negative() *Vector3 {
-	return &Vector3{
+func (first Vector3) Negative() Vector3 {
+	return Vector3{
 		X: -first.X,
 		Y: -first.Y,
 		Z: -first.Z,
 	}
 }
 
-func (first *Vector3) DotProduct(second *Vector3) float64 {
+func (first Vector3) DotProduct(second Vector3) float64 {
 	return first.X*second.X + (first.Y * second.Y) + (first.Z * second.Z)
 }
 
-func (first *Vector3) CrossProduct(second *Vector3) *Vector3 {
-	return &Vector3{
+func (first Vector3) CrossProduct(second Vector3) Vector3 {
+	return Vector3{
 		X: (first.Y * second.Z) - (first.Z * second.Y),
 		Y: (first.Z * second.X) - (first.X * second.Z),
 		Z: (first.X * second.Y) - (first.Y * second.X),

--- a/math/vector4.go
+++ b/math/vector4.go
@@ -4,8 +4,8 @@ type Vector4 struct {
 	X, Y, Z, T float64
 }
 
-func (first Vector4) multiply(second Vector4) *Vector4 {
-	return &Vector4{
+func (first Vector4) multiply(second Vector4) Vector4 {
+	return Vector4{
 		X: first.X * second.X,
 		Y: first.Y * second.Y,
 		Z: first.Z * second.Z,
@@ -13,8 +13,8 @@ func (first Vector4) multiply(second Vector4) *Vector4 {
 	}
 }
 
-func (first Vector4) add(second Vector4) *Vector4 {
-	return &Vector4{
+func (first Vector4) add(second Vector4) Vector4 {
+	return Vector4{
 		X: first.X + second.X,
 		Y: first.Y + second.Y,
 		Z: first.Z + second.Z,
@@ -22,8 +22,8 @@ func (first Vector4) add(second Vector4) *Vector4 {
 	}
 }
 
-func (first Vector4) subtract(second Vector4) *Vector4 {
-	return &Vector4{
+func (first Vector4) subtract(second Vector4) Vector4 {
+	return Vector4{
 		X: first.X - second.X,
 		Y: first.Y - second.Y,
 		Z: first.Z - second.Z,

--- a/raytracer/camera.go
+++ b/raytracer/camera.go
@@ -6,14 +6,14 @@ import (
 )
 
 type Camera struct {
-	eye, up, direction          *math.Vector3
+	eye, up, direction          math.Vector3
 	fov, distance               float64
 	nx, ny                      int
 	l, r, b, t, tanfov2, nxopny float64
-	w, u, v                     *math.Vector3
+	w, u, v                     math.Vector3
 }
 
-func (camera *Camera) getRayDirection(x, y int) *math.Vector3 {
+func (camera *Camera) getRayDirection(x, y int) math.Vector3 {
 	uVal := camera.l + (camera.r-camera.l)*(float64(x)+0.5)/float64(camera.nx)
 	vVal := camera.b + (camera.t-camera.b)*(float64(y)+0.5)/float64(camera.ny)
 	utimes := camera.u.MultiplyFloat(uVal)
@@ -29,7 +29,7 @@ func (camera *Camera) GenerateRay(x, y int) Ray {
 	return NewRay(camera.eye, rayDir)
 }
 
-func GetCamera(eye, up, direction *math.Vector3, fov, distance float64, nx, ny int) Camera {
+func GetCamera(eye, up, direction math.Vector3, fov, distance float64, nx, ny int) Camera {
 	normalUp := up.Normalize()
 	normalDir := direction.Normalize()
 	w := normalDir.Negative()

--- a/raytracer/integrator.go
+++ b/raytracer/integrator.go
@@ -5,5 +5,5 @@ import (
 )
 
 type Integrator interface {
-	RenderRay(ray *Ray) *math.Color3
+	RenderRay(ray *Ray) math.Color3
 }

--- a/raytracer/light.go
+++ b/raytracer/light.go
@@ -5,5 +5,5 @@ import (
 )
 
 type Light interface {
-	SampleLight(hit *math.Vector3) (*math.Vector3, float64, *math.Color3)
+	SampleLight(hit math.Vector3) (math.Vector3, float64, math.Color3)
 }

--- a/raytracer/material.go
+++ b/raytracer/material.go
@@ -5,5 +5,5 @@ import (
 )
 
 type Material interface {
-	Shade(in *math.Vector3, out *math.Vector3, ray *Ray) *math.Color3
+	Shade(in math.Vector3, out math.Vector3, ray *Ray) math.Color3
 }

--- a/raytracer/ray.go
+++ b/raytracer/ray.go
@@ -6,12 +6,12 @@ import (
 )
 
 type Ray struct {
-	Eye         *math.Vector3
-	Direction   *math.Vector3
+	Eye         math.Vector3
+	Direction   math.Vector3
 	HitDistance float64
 	Hit         bool
 	Geometry    Geometry
-	Normal      *math.Vector3
+	Normal      math.Vector3
 }
 
 func (ray *Ray) IsHit(f float64, geometry Geometry) bool {
@@ -24,11 +24,11 @@ func (ray *Ray) IsHit(f float64, geometry Geometry) bool {
 	return false
 }
 
-func (ray *Ray) HitPoint() *math.Vector3 {
+func (ray *Ray) HitPoint() math.Vector3 {
 	return ray.Direction.MultiplyFloat(ray.HitDistance).Add(ray.Eye)
 }
 
-func NewRay(eye *math.Vector3, direction *math.Vector3) Ray {
+func NewRay(eye math.Vector3, direction math.Vector3) Ray {
 	return Ray{
 		Eye:         eye,
 		Direction:   direction,

--- a/utils/Canvas.go
+++ b/utils/Canvas.go
@@ -20,7 +20,7 @@ func CreateCanvas(size image.Point) *Canvas {
 	}
 }
 
-func (canvas *Canvas) Put(x, y int, color *math.Color3) {
+func (canvas *Canvas) Put(x, y int, color math.Color3) {
 	canvas.image.Set(x, canvas.Size.Y-y, color.RGBA64())
 }
 


### PR DESCRIPTION
Timings without pointers:
```
sdehaes@DESKTOP-TK2UFOK:~/opensource/go-tracer$ time go run main.go
Starting op 24 workers

real    1m14.032s
user    29m24.047s
sys     0m2.198s
sdehaes@DESKTOP-TK2UFOK:~/opensource/go-tracer$ time go run main.go
Starting op 24 workers

real    1m13.972s
user    29m24.106s
sys     0m2.287s

```

Timings with pointers:
```
sdehaes@DESKTOP-TK2UFOK:~/opensource/go-tracer$ time go run main.go
Starting op 24 workers

real    1m18.766s
user    31m16.064s
sys     0m4.126s
sdehaes@DESKTOP-TK2UFOK:~/opensource/go-tracer$ time go run main.go
Starting op 24 workers

real    1m18.205s
user    31m4.662s
sys     0m2.269s
```

So it is objectively a bit faster